### PR TITLE
Page title changed from default to CadHub

### DIFF
--- a/web/src/index.html
+++ b/web/src/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/png" href="/favicon.png" />
-    <title><%= htmlWebpackPlugin.options.title %></title>
+    <title>CadHub</title>
     <script>
       // Install Cascade Studio as a Progressive Web App for Offline Access
       // This needs to be put before ANY HTTP Requests are made, so it can cache them.


### PR DESCRIPTION
#18 
The default title is taken from the root folder. The core dev team said that this is just a temporary title and meant to be change later.
 [https://community.redwoodjs.com/t/change-a-page-title/1205/3](https://community.redwoodjs.com/t/change-a-page-title/1205/3)

If you want some more control over the title they recommend implementing a head manager like [react-helmet](https://github.com/nfl/react-helmet).