### PR TITLE
Link to road map in the app and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Let's help Code-CAD reach its [full potential!](https://cadhub.xyz) We're making a ~~cad~~hub for the Code-CAD community, think of it as model-repository crossed with a live editor. We have an integration with the excellent [cascadeStudio](https://zalo.github.io/CascadeStudio/) with [more coming soon](https://github.com/Irev-Dev/curated-code-cad).
 
-If you want to be involved in anyway, get in touch via, [twitter](https://twitter.com/IrevDev), [discord](https://discord.gg/SD7zFRNjGH) or [discussions](https://github.com/Irev-Dev/cadhub/discussions).
+If you want to be involved in anyway, checkout the [Road Map](https://github.com/Irev-Dev/cadhub/discussions/212) and get in touch via, [twitter](https://twitter.com/IrevDev), [discord](https://discord.gg/SD7zFRNjGH) or [discussions](https://github.com/Irev-Dev/cadhub/discussions).
 
 <img src="https://raw.githubusercontent.com/Irev-Dev/repo-images/main/images/fullcadhubshot.jpg">
 

--- a/web/src/components/Footer/Footer.js
+++ b/web/src/components/Footer/Footer.js
@@ -1,9 +1,16 @@
 import { Link, routes } from '@redwoodjs/router'
+import OutBound from 'src/components/OutBound'
 
 const Footer = () => {
   return (
     <div className="bg-indigo-900 text-indigo-200 font-roboto mt-20 text-sm">
       <div className="flex h-16 justify-end items-center mx-16">
+        <OutBound
+          className="mr-8"
+          to="https://github.com/Irev-Dev/cadhub/discussions/212"
+        >
+          Road Map
+        </OutBound>
         <Link className="mr-8" to={routes.codeOfConduct()}>
           Code of Conduct
         </Link>

--- a/web/src/components/LandingSection/LandingSection.js
+++ b/web/src/components/LandingSection/LandingSection.js
@@ -154,7 +154,14 @@ const LandingSection = () => {
             >
               CascadeStudio
             </OutBound>{' '}
-            with more integrations coming soon.
+            with more integrations{' '}
+            <OutBound
+              className="text-gray-600 underline"
+              to="https://github.com/Irev-Dev/cadhub/discussions/212"
+            >
+              coming soon
+            </OutBound>
+            .
           </p>
           <Link to={routes.draftPart()}>
             <div className="bg-texture bg-purple-800 text-center w-full py-6 rounded-b-md border border-indigo-300 border-opacity-0 hover:border-opacity-100 hover:shadow-xl">

--- a/web/src/components/OutBound/OutBound.js
+++ b/web/src/components/OutBound/OutBound.js
@@ -4,6 +4,7 @@ const OutBound = ({ className, children, to }) => {
   return (
     <a
       className={className}
+      target="_blank"
       href={to}
       onClick={() => {
         ReactGA.event({


### PR DESCRIPTION
it's a good idea to link to the roadmap somewhere in the app. It's a
good way of letting folks who are interested in Cadhub see where it's
going. Link to the GH discussion for now.

Maybe later if we're confident in the features we want and we've added
docs to the website we can add something a bit more official.

Add a link to the read me as well!
resolves #213