### PR TITLE
Showing state being passed into `useIdeState` dispatch middleware

### DIFF
--- a/web/src/components/IdeToolbarNew/IdeToolbarNew.js
+++ b/web/src/components/IdeToolbarNew/IdeToolbarNew.js
@@ -6,10 +6,16 @@ export const IdeContext = createContext()
 
 const IdeToolbarNew = () => {
   const [state, dispatch] = useIdeState()
+  function setIdeType(ide) { dispatch({ type: 'setIdeType', payload: { message: ide } }) }
+
   return (
     <IdeContext.Provider value={{ state, dispatch }}>
       <div className="p-8 border-2">
         <div>hi I'm the toolbar</div>
+        <nav class="flex">
+          <button onClick={() => setIdeType('openCascade')} class="p-2 br-2 border-2 m-2 bg-blue-200">Switch to OpenCascade</button>
+          <button onClick={() => setIdeType('openScad')} class="p-2 br-2 border-2 m-2 bg-indigo-200">Switch to OpenSCAD</button>
+        </nav>
         <IdeContainer />
       </div>
     </IdeContext.Provider>

--- a/web/src/components/IdeViewer/IdeViewer.js
+++ b/web/src/components/IdeViewer/IdeViewer.js
@@ -9,7 +9,8 @@ const IdeViewer = () => {
       <div>
         I should be showing an{' '}
         <span className="font-mono uppercase">{state.objectData?.type}</span>{' '}
-        right now
+        right now with the data{' '}
+        <span className="font-mono uppercase">{state.objectData?.data}</span>{' '}
       </div>
     </div>
   )

--- a/web/src/helpers/cadPackages/index.js
+++ b/web/src/helpers/cadPackages/index.js
@@ -1,0 +1,7 @@
+import openScad from './openScadController'
+import openCascade from './newCascadeController'
+
+export const cadPackages = {
+  openScad,
+  openCascade,
+}

--- a/web/src/helpers/cadPackages/newCascadeController.js
+++ b/web/src/helpers/cadPackages/newCascadeController.js
@@ -8,7 +8,7 @@ export const render = async ({ code, settings }) => {
         resolve({
           objectData: {
             type: 'stl',
-            data: ((Math.random() * 256 + 1) >>> 0).toString(2),
+            data: ((Math.random() * 256 + 1) >>> 0).toString(2), // Randomized 8-bit numbers for funzies
           },
           message: {
             type: 'message',

--- a/web/src/helpers/cadPackages/newCascadeController.js
+++ b/web/src/helpers/cadPackages/newCascadeController.js
@@ -1,0 +1,35 @@
+// Rename this file to remove "new" once Cascade integration is complete
+
+export const render = async ({ code, settings }) => {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      const shouldReject = Math.random() < 0.7
+      if (shouldReject) {
+        resolve({
+          objectData: {
+            type: 'stl',
+            data: ((Math.random() * 256 + 1) >>> 0).toString(2),
+          },
+          message: {
+            type: 'message',
+            message: `bodies rendered by: ${code}`,
+          },
+        })
+      } else {
+        reject({
+          message: {
+            type: 'error',
+            message: 'unable to parse line: x',
+          },
+        })
+      }
+    }, 700)
+  })
+}
+
+const openCascade = {
+  render,
+  // More functions to come
+}
+
+export default openCascade

--- a/web/src/helpers/cadPackages/openScadController.js
+++ b/web/src/helpers/cadPackages/openScadController.js
@@ -6,7 +6,7 @@ export const render = async ({ code, settings }) => {
         resolve({
           objectData: {
             type: 'jpg',
-            data: ((Math.random() * 256 + 1) >>> 0).toString(2),
+            data: ((Math.random() * 256 + 1) >>> 0).toString(2), // Randomized 8-bit numbers for funzies
           },
           message: {
             type: 'message',
@@ -28,6 +28,7 @@ export const render = async ({ code, settings }) => {
 
 const openScad = {
   render,
+  // more functions to come
 }
 
 export default openScad

--- a/web/src/helpers/cadPackages/openScadController.js
+++ b/web/src/helpers/cadPackages/openScadController.js
@@ -1,12 +1,12 @@
-export const renderOpenScad = async ({ code, settings }) => {
+export const render = async ({ code, settings }) => {
   return new Promise((resolve, reject) => {
     setTimeout(() => {
       const shouldReject = Math.random() < 0.7
       if (shouldReject) {
         resolve({
           objectData: {
-            type: Math.random() > 0.6 ? 'stl' : 'jpg',
-            data: 'some binary',
+            type: 'jpg',
+            data: ((Math.random() * 256 + 1) >>> 0).toString(2),
           },
           message: {
             type: 'message',
@@ -24,3 +24,10 @@ export const renderOpenScad = async ({ code, settings }) => {
     }, 700)
   })
 }
+
+
+const openScad = {
+  render,
+}
+
+export default openScad

--- a/web/src/helpers/hooks/useIdeState.js
+++ b/web/src/helpers/hooks/useIdeState.js
@@ -1,9 +1,9 @@
 import { useReducer } from 'react'
-import { renderOpenScad } from 'src/helpers/openScadController'
+import { cadPackages } from 'src/helpers/cadPackages'
 
 export const useIdeState = () => {
   const initialState = {
-    ideType: 'openscad',
+    ideType: 'openScad',
     consoleMessages: [
       { type: 'error', message: 'line 15 is being very naughty' },
       { type: 'message', message: '5 bodies produced' },
@@ -36,14 +36,19 @@ export const useIdeState = () => {
             ? [...state.consoleMessages, payload.message]
             : payload.message,
         }
+      case 'setIdeType':
+        return {
+          ...state,
+          ideType: payload.message,
+        }
     }
   }
 
-  function dispatchMiddleware(dispatch) {
+  function dispatchMiddleware(dispatch, state) {
     return ({ type, payload }) => {
       switch (type) {
         case 'render':
-          renderOpenScad({ code: payload.code })
+          cadPackages[state.ideType].render({ code: payload.code })
             .then(({ objectData, message }) =>
               dispatch({
                 type: 'healthyRender',
@@ -65,5 +70,5 @@ export const useIdeState = () => {
   }
 
   const [state, dispatch] = useReducer(reducer, initialState)
-  return [state, dispatchMiddleware(dispatch)]
+  return [state, dispatchMiddleware(dispatch, state)]
 }


### PR DESCRIPTION
I also made some minor tweaks, moved that new openSCAD controller into a `cadPackages` subdirectory and duplicated it to make a faux openCascade controller as well, so that by switching between them you can see the `objectData` type changes between `stl` and `jpg`.