### PR TITLE
Fix camera perspective and other polish for openscad viewer

### DIFF
--- a/api/src/docker/openscad/runScad.js
+++ b/api/src/docker/openscad/runScad.js
@@ -17,7 +17,7 @@ module.exports.runScad = async ({
   const { x: rx, y: ry, z: rz } = rotation
   const { x: px, y: py, z: pz } = position
   const cameraArg = `--camera=${px},${py},${pz},${rx},${ry},${rz},300`
-  const command = `xvfb-run --auto-servernum --server-args "-screen 0 1024x768x24" openscad -o /tmp/${tempFile}/output.png ${cameraArg} --imgsize=${x},${y} /tmp/${tempFile}/main.scad`
+  const command = `xvfb-run --auto-servernum --server-args "-screen 0 1024x768x24" openscad -o /tmp/${tempFile}/output.png ${cameraArg} --imgsize=${x},${y} --colorscheme DeepOcean /tmp/${tempFile}/main.scad`
   console.log('command', command)
 
   try {

--- a/web/src/components/IdeViewer/IdeViewer.js
+++ b/web/src/components/IdeViewer/IdeViewer.js
@@ -6,7 +6,7 @@ import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls'
 extend({ OrbitControls })
 
 let debounceTimeoutId
-function Controls({ onCameraChange }) {
+function Controls({ onCameraChange, onDragStart }) {
   const controls = useRef()
   const { scene, camera, gl } = useThree()
   useEffect(() => {
@@ -47,7 +47,10 @@ function Controls({ onCameraChange }) {
           })
         }, 400)
       }
-      const dragStart = () => clearTimeout(debounceTimeoutId)
+      const dragStart = () => {
+        onDragStart()
+        clearTimeout(debounceTimeoutId)
+      }
       controls.current.addEventListener('end', dragCallback)
       controls.current.addEventListener('start', dragStart)
       const oldCurrent = controls.current
@@ -120,6 +123,7 @@ const IdeViewer = () => {
         >
           <Canvas>
             <Controls
+              onDragStart={() => setIsDragging(true)}
               onCameraChange={({ position, rotation }) => {
                 dispatch({
                   type: 'render',

--- a/web/src/components/IdeViewer/IdeViewer.js
+++ b/web/src/components/IdeViewer/IdeViewer.js
@@ -1,10 +1,11 @@
 import { IdeContext } from 'src/components/IdeToolbarNew'
-import { useRef, useState, useEffect, useContext, useMemo } from 'react'
+import { useRef, useState, useEffect, useContext } from 'react'
 import { Canvas, extend, useFrame, useThree } from 'react-three-fiber'
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls'
 
 extend({ OrbitControls })
 
+let debounceTimeoutId
 function Controls({ onCameraChange }) {
   const controls = useRef()
   const { scene, camera, gl } = useThree()
@@ -12,41 +13,48 @@ function Controls({ onCameraChange }) {
     // init camera position
     camera.position.x = 16
     camera.position.y = 12
-    console.log(camera)
     camera.fov = 22.5 // matches default openscad fov
 
     // Order matters with Euler rotations
     // We want it to rotate around the z or vertical axis first then the x axis to match openscad
     // in Three.js Y is the vertical axis (Z for openscad)
     camera.rotation._order = 'YXZ'
+    const getRotations = () => {
+      const { x, y, z } = camera.rotation
+      const rad2Deg = 180 / Math.PI
+      const scadX = (x + Math.PI / 2) * rad2Deg
+      const scadZ = y * rad2Deg
+      const scadY = z * rad2Deg
+      return [scadX, scadY, scadZ]
+    }
+    const getPositions = () => {
+      const { x: scadX, y: scadZ, z: negScadY } = camera.position
+      const scale = 10
+      const scadY = -negScadY
+      return [scadX * scale, scadY * scale, scadZ * scale]
+    }
 
     if (controls.current) {
-      const callback = ({ target }) => {
-        const getRotations = () => {
-          const { x, y, z } = target.object.rotation
-          const rad2Deg = 180 / Math.PI
-          const scadX = (x + Math.PI / 2) * rad2Deg
-          const scadZ = y * rad2Deg
-          const scadY = z * rad2Deg
-          return [scadX, scadY, scadZ]
-        }
-        const getPositions = () => {
-          const { x: scadX, y: scadZ, z: negScadY } = target.object.position
-          const scale = 10
-          const scadY = -negScadY
-          return [scadX * scale, scadY * scale, scadZ * scale]
-        }
-        const [rx, ry, rz] = getRotations()
-        const [x, y, z] = getPositions()
+      const dragCallback = () => {
+        clearTimeout(debounceTimeoutId)
+        debounceTimeoutId = setTimeout(() => {
+          const [rx, ry, rz] = getRotations()
+          const [x, y, z] = getPositions()
 
-        onCameraChange({
-          position: { x, y, z },
-          rotation: { x: rx, y: ry, z: rz },
-        })
+          onCameraChange({
+            position: { x, y, z },
+            rotation: { x: rx, y: ry, z: rz },
+          })
+        }, 400)
       }
-      controls.current.addEventListener('end', callback)
+      const dragStart = () => clearTimeout(debounceTimeoutId)
+      controls.current.addEventListener('end', dragCallback)
+      controls.current.addEventListener('start', dragStart)
       const oldCurrent = controls.current
-      return () => oldCurrent.removeEventListener('end', callback)
+      return () => {
+        oldCurrent.removeEventListener('end', dragCallback)
+        oldCurrent.removeEventListener('start', dragStart)
+      }
     }
   }, [])
 
@@ -55,8 +63,6 @@ function Controls({ onCameraChange }) {
     <orbitControls
       ref={controls}
       args={[camera, gl.domElement]}
-      enableDamping
-      dampingFactor={0.1}
       rotateSpeed={0.5}
     />
   )
@@ -77,32 +83,39 @@ let currentCode // I have no idea why this works and using state.code is the dis
 const IdeViewer = () => {
   const { state, dispatch } = useContext(IdeContext)
   const [isDragging, setIsDragging] = useState(false)
+  const [image, setImage] = useState()
 
-  const image = useMemo(
-    () =>
+  useEffect(() => {
+    setImage(
       state.objectData?.type === 'png' &&
-      state.objectData?.data &&
-      window.URL.createObjectURL(state.objectData?.data),
-    [state.objectData]
-  )
+        state.objectData?.data &&
+        window.URL.createObjectURL(state.objectData?.data)
+    )
+    setIsDragging(false)
+  }, [state.objectData])
   currentCode = state.code
   return (
     <div className="p-8 border-2 m-2">
       <div className="relative" style={{ height: '500px', width: '500px' }}>
+        {state.isLoading && (
+          <div className="inset-0 absolute flex items-center justify-center">
+            <div className="h-16 w-16 bg-pink-600 rounded-full animate-ping"></div>
+          </div>
+        )}
         {image && (
           <div
-            className="absolute inset-0"
-            style={{ opacity: isDragging ? '0%' : '100%' }}
+            className={`absolute inset-0 transition-opacity duration-500 ${
+              isDragging ? 'opacity-25' : 'opacity-100'
+            }`}
           >
             <img src={image} className="" />
           </div>
         )}
         <div
-          className={`opacity-0 absolute inset-0 ${
+          className={`opacity-0 opacity- absolute inset-0 transition-opacity duration-500 ${
             isDragging ? 'opacity-100' : 'hover:opacity-50'
           }`}
           onMouseDown={() => setIsDragging(true)}
-          onMouseUp={() => setIsDragging(false)}
         >
           <Canvas>
             <Controls
@@ -121,9 +134,17 @@ const IdeViewer = () => {
             />
             <ambientLight />
             <pointLight position={[15, 5, 10]} />
-            <Box position={[0, 5, 0]} size={[0.1, 10, 0.1]} color="cyan" />
-            <Box position={[0, 0, -5]} size={[0.1, 0.1, 10]} color="orange" />
-            <Box position={[5, 0, 0]} size={[10, 0.1, 0.1]} color="hotpink" />
+            <Box position={[0, 4.95, 0]} size={[0.1, 10, 0.1]} color="cyan" />
+            <Box
+              position={[0, 0, -5.05]}
+              size={[0.1, 0.1, 10]}
+              color="orange"
+            />
+            <Box
+              position={[5.05, 0, 0]}
+              size={[10, 0.1, 0.1]}
+              color="hotpink"
+            />
           </Canvas>
         </div>
       </div>

--- a/web/src/components/IdeViewer/IdeViewer.js
+++ b/web/src/components/IdeViewer/IdeViewer.js
@@ -116,7 +116,7 @@ const IdeViewer = () => {
           </div>
         )}
         <div
-          className={`opacity-0 opacity- absolute inset-0 transition-opacity duration-500 ${
+          className={`opacity-0 absolute inset-0 transition-opacity duration-500 ${
             isDragging ? 'opacity-100' : 'hover:opacity-50'
           }`}
           onMouseDown={() => setIsDragging(true)}

--- a/web/src/components/IdeViewer/IdeViewer.js
+++ b/web/src/components/IdeViewer/IdeViewer.js
@@ -51,6 +51,7 @@ function Controls({ onCameraChange }) {
       controls.current.addEventListener('end', dragCallback)
       controls.current.addEventListener('start', dragStart)
       const oldCurrent = controls.current
+      dragCallback()
       return () => {
         oldCurrent.removeEventListener('end', dragCallback)
         oldCurrent.removeEventListener('start', dragStart)

--- a/web/src/components/IdeViewer/IdeViewer.js
+++ b/web/src/components/IdeViewer/IdeViewer.js
@@ -10,11 +10,14 @@ function Controls({ onCameraChange }) {
   const { scene, camera, gl } = useThree()
   useEffect(() => {
     // init camera position
-    camera.position.x = 12
+    camera.position.x = 16
     camera.position.y = 12
-    // Euler rotation can be problematic since order matters
-    // We want it to rotate around the z or vertical axis first then the x axis
-    // in Three Y is the vertical axis (Z for openscad)
+    console.log(camera)
+    camera.fov = 22.5 // matches default openscad fov
+
+    // Order matters with Euler rotations
+    // We want it to rotate around the z or vertical axis first then the x axis to match openscad
+    // in Three.js Y is the vertical axis (Z for openscad)
     camera.rotation._order = 'YXZ'
 
     if (controls.current) {
@@ -29,7 +32,7 @@ function Controls({ onCameraChange }) {
         }
         const getPositions = () => {
           const { x: scadX, y: scadZ, z: negScadY } = target.object.position
-          const scale = 10 // I'm not sure why this is exactly 10
+          const scale = 10
           const scadY = -negScadY
           return [scadX * scale, scadY * scale, scadZ * scale]
         }
@@ -65,7 +68,7 @@ function Box(props) {
 
   return (
     <mesh {...props} ref={mesh} scale={[1, 1, 1]}>
-      <boxBufferGeometry args={[props.size, props.size, props.size]} />
+      <boxBufferGeometry args={props.size} />
       <meshStandardMaterial color={props.color} />
     </mesh>
   )
@@ -85,14 +88,6 @@ const IdeViewer = () => {
   currentCode = state.code
   return (
     <div className="p-8 border-2 m-2">
-      <div className="pb-4">
-        Rotating the Three.js Cube should than update the openscad camera to
-        view the CAD object from the same angle. But having trouble translating
-        between the two coordinate systems. OpenScad's camera only changes X and
-        Z angles and Y is always 0. Where as rotation values from Three seem to
-        change all x, y and z. I probably need to learn a bit more about 3d
-        math.
-      </div>
       <div className="relative" style={{ height: '500px', width: '500px' }}>
         {image && (
           <div
@@ -126,10 +121,9 @@ const IdeViewer = () => {
             />
             <ambientLight />
             <pointLight position={[15, 5, 10]} />
-            <Box position={[0, 0, 0]} size={10} color="orange" />
-            <Box position={[0, 5, 0]} size={1} color="cyan" />
-            <Box position={[0, 0, 5]} size={1} color="magenta" />
-            <Box position={[5, 0, 0]} size={1} color="hotpink" />
+            <Box position={[0, 5, 0]} size={[0.1, 10, 0.1]} color="cyan" />
+            <Box position={[0, 0, -5]} size={[0.1, 0.1, 10]} color="orange" />
+            <Box position={[5, 0, 0]} size={[10, 0.1, 0.1]} color="hotpink" />
           </Canvas>
         </div>
       </div>

--- a/web/src/helpers/hooks/useIdeState.js
+++ b/web/src/helpers/hooks/useIdeState.js
@@ -4,11 +4,14 @@ import { cadPackages } from 'src/helpers/cadPackages'
 export const useIdeState = () => {
   const initialState = {
     ideType: 'openScad',
-    consoleMessages: [
-      { type: 'error', message: 'line 15 is being very naughty' },
-      { type: 'message', message: '5 bodies produced' },
-    ],
-    code: 'cube(60);sphere(25);',
+    consoleMessages: [{ type: 'message', message: 'Initialising OpenSCAD' }],
+    code: `difference(){
+  union(){
+    cube(60);
+    sphere(25);
+  }
+  translate([30,30,30])cylinder(r=25,h=100);
+}`,
     objectData: {
       type: 'stl',
       data: 'some binary',

--- a/web/src/helpers/hooks/useIdeState.js
+++ b/web/src/helpers/hooks/useIdeState.js
@@ -23,6 +23,7 @@ export const useIdeState = () => {
         splitPercentage: 70,
       },
     },
+    isLoading: false,
   }
   const reducer = (state, { type, payload }) => {
     switch (type) {
@@ -38,6 +39,7 @@ export const useIdeState = () => {
           consoleMessages: payload.message
             ? [...state.consoleMessages, payload.message]
             : payload.message,
+          isLoading: false,
         }
       case 'errorRender':
         return {
@@ -45,6 +47,7 @@ export const useIdeState = () => {
           consoleMessages: payload.message
             ? [...state.consoleMessages, payload.message]
             : payload.message,
+          isLoading: false,
         }
       case 'setIdeType':
         return {
@@ -55,6 +58,11 @@ export const useIdeState = () => {
         return {
           ...state,
           layout: payload.message,
+        }
+      case 'setLoading':
+        return {
+          ...state,
+          isLoading: true,
         }
       default:
         return state
@@ -83,6 +91,7 @@ export const useIdeState = () => {
                 })
               }
             })
+          dispatch({ type: 'setLoading' })
           break
 
         default:


### PR DESCRIPTION
> * I don't think you need that explanatory paragraph up top after this resolution right?

Yup gone.
> * Trying it out I actually enjoyed having the image remain slightly visible while dragging the cube, maybe 20-30%, 
because I could better gauge how much I was changing the view. What are your thoughts?

I wasn't too keen on this, but I added it and yeah, I like it. 🥇 
> * I think we should update the default OpenSCAD camera state to match your ThreeJS camera, because as of now the 
initial render doesn't align to the view cube but it starts to after your first adjustment with the cube.

Yes, so this is whole topic that I might see if openscad folks have any insight into, the main thing that made it look bad was the fov is different between the two. so I've set the three.js fov to match openscad default fov and it looks good (though in the latest openscad it's possible to change the fov in code with which might cause headaches). One thing I can't get working is when you "move the shape" with right click, they axis and the shape no long line up. This seems like a simple matter of scale. I experimented with a number of things, the thing I had most luck with was changing the openscad camera distance to something very low ([this line](https://github.com/Irev-Dev/cadhub/blob/main/api/src/docker/openscad/runScad.js#L19) ) `--camera=${px},${py},${pz},${rx},${ry},${rz},300` the last number currently 300, if I change that something very low, like 5 or less, than the moving situation becomes much better (not perfect but better), but making that very low also seems to change the (not sure of the right term) clipping distance, as in the distance at which the objects are out of sight of the camera, so it's not practical to have it that low.

There might not be a solution since we're really pushing openscad outside of its normal use. But maybe there's something we can do the three.js side too, some scaling factor?

Other things I've done.

- Changed the reference cube to a set of axes, What do you think?
- Added a loading animation
- Firing a new image load is debounced/deffered by 400 ms, makes scroll/zoom not fire off one million requests
- general polish. I added 500ms transitions to the opacity changes, too slow?


https://user-images.githubusercontent.com/29681384/110915333-9a654700-836b-11eb-83e5-29cdd7bb83df.mov



With the polish I've been doing I'm a bit concerned I'm designing in code, without having thought about what it should look like prior to. It might be a good idea to take a break and give that a proper thing (not that it can't be changed later). Maybe I should be more concerned with getting a MVP working 🤷 

One simple design choice is what color scheme do we want for the openscad output? lol

Tomorrow night
![image](https://user-images.githubusercontent.com/29681384/110912869-8d932400-8368-11eb-920c-81f8d945432c.png)

Tomorrow 
![image](https://user-images.githubusercontent.com/29681384/110912853-879d4300-8368-11eb-8fd7-b99f94df3dda.png)

Solarized
![image](https://user-images.githubusercontent.com/29681384/110912837-81a76200-8368-11eb-958f-98323b8e6bf6.png)

DeepOcean
![image](https://user-images.githubusercontent.com/29681384/110912816-7b18ea80-8368-11eb-961e-159579280047.png)

Nature
![image](https://user-images.githubusercontent.com/29681384/110912798-75bba000-8368-11eb-9159-acf599c8a685.png)


BeforeDawn
![image](https://user-images.githubusercontent.com/29681384/110912775-6fc5bf00-8368-11eb-8593-c1688f77669b.png)


Starnight
![image](https://user-images.githubusercontent.com/29681384/110912758-6b010b00-8368-11eb-9b7e-b732a64f5c1c.png)

Sunset
![image](https://user-images.githubusercontent.com/29681384/110912221-caaae680-8367-11eb-9096-bdf00adf0f99.png)

Metalic
![image](https://user-images.githubusercontent.com/29681384/110912207-c41c6f00-8367-11eb-9dd0-8b845a861365.png)

Cornfield
![image](https://user-images.githubusercontent.com/29681384/110912188-be268e00-8367-11eb-8fb9-aaeabf628328.png)

resolves #237 