### PR TITLE
Move local development openSCAD url to env vars

### DIFF
--- a/api/src/docker/README.md
+++ b/api/src/docker/README.md
@@ -13,20 +13,21 @@ You'll need to have Docker installed
 
 Because of the way the docker containers to be deployed as lambdas on aws are somewhat specialised for the purpose we're using `docker-compose` to spin one up for each function/endpoint. So we've added a aws-emulation layer
 
-first cd into this folder `cd api/src/docker`
-then
+
+Then cd into this folder `cd api/src/docker` and:
 
 ```bash
 docker-compose up --build
 ```
-The first time you run the, when it has to build the main image it will take some time, but launching again will be quicker.
+The first time you run this, it has to build the main image it will take some time, but launching again will be quicker.
 
 After which we'll also spin up a light express server to act as an emulator to transform some the request from the front end into how the lambda's expect them.
 ```
 yarn install
 yarn emulate
 ```
-You can now change the url in `web/src/helpers/cadPackages/openScadController.js` from the aws url to `http://localhost:8080`
+You can now add OPENSCAD_BASE_URL="http://localhost:8080" to you .env file and restart your main dev process (`yarn rw dev`)
+comment that line out if you want to go back to using the aws endpoint (and restart the dev process).
 
 If you change anything in the `api/src/docker/openscad` directory, you will need to stop the docker process and restart it (will be fairly quick if you're only changing the js)
 

--- a/web/src/helpers/cadPackages/openScadController.js
+++ b/web/src/helpers/cadPackages/openScadController.js
@@ -1,5 +1,5 @@
-// const openScadBaseURL = 'http://localhost:8080' // for local development
-const openScadBaseURL =
+let openScadBaseURL =
+  process.env.OPENSCAD_BASE_URL ||
   'https://x2wvhihk56.execute-api.us-east-1.amazonaws.com/dev'
 
 export const render = async ({ code, settings }) => {


### PR DESCRIPTION
I think this make it easier to swap between using the aws endpoint and
local endpoint but without having to worry about accidentally committing
the local endpoint if you absent mindedly staging everything, and it
still defaults to aws so it's easy setup for anyone doing a fresh clone.

add OPENSCAD_BASE_URL="http://localhost:8080" to you .env file.

You will have to restart yarn rw dev for the url to swap over though.

I'm not sure if you set up the local aws stuff or not, but just an FYI for future if you do @franknoirot 

Resolves #242