### PR TITLE
added multiplication by device pixel ratio to render

### DIFF
--- a/web/src/helpers/cadPackages/openScadController.js
+++ b/web/src/helpers/cadPackages/openScadController.js
@@ -6,10 +6,12 @@ let lastViewPortSize = 'INIT'
 let lastCameraSettings = 'INIT'
 
 export const render = async ({ code, settings }) => {
+  const pixelRatio = window.devicePixelRatio || 1
+  console.log({ pixelRatio })
   const size = settings.viewerSize
     ? {
-        x: Math.round(settings.viewerSize?.width),
-        y: Math.round(settings.viewerSize?.height),
+        x: Math.round(settings.viewerSize?.width * pixelRatio),
+        y: Math.round(settings.viewerSize?.height * pixelRatio),
       }
     : lastViewPortSize
   const camera = settings.camera || lastCameraSettings

--- a/web/src/helpers/cadPackages/openScadController.js
+++ b/web/src/helpers/cadPackages/openScadController.js
@@ -7,7 +7,6 @@ let lastCameraSettings = 'INIT'
 
 export const render = async ({ code, settings }) => {
   const pixelRatio = window.devicePixelRatio || 1
-  console.log({ pixelRatio })
   const size = settings.viewerSize
     ? {
         x: Math.round(settings.viewerSize?.width * pixelRatio),


### PR DESCRIPTION
Little addition to scale the OpenSCAD render depending on the device's `pixelRatio`. Resolves the last requirement for #239.