### PR TITLE
Add the ability to link to text resource for IDE

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # [C a d H u b](https://cadhub.xyz)
 
-[![Netlify Status](https://api.netlify.com/api/v1/badges/77f37543-e54a-4723-8136-157c0221ec27/deploy-status)](https://app.netlify.com/sites/cadhubxyz/deploys)
+<!-- [![Netlify Status](https://api.netlify.com/api/v1/badges/77f37543-e54a-4723-8136-157c0221ec27/deploy-status)](https://app.netlify.com/sites/cadhubxyz/deploys) -->
 
 Let's help Code-CAD reach its [full potential!](https://cadhub.xyz) We're making a ~~cad~~hub for the Code-CAD community, think of it as model-repository crossed with a live editor. We have an integration with the excellent [cascadeStudio](https://zalo.github.io/CascadeStudio/) with [more coming soon](https://github.com/Irev-Dev/curated-code-cad).
 

--- a/app/web/package.json
+++ b/app/web/package.json
@@ -26,6 +26,7 @@
     "golden-layout": "^1.5.9",
     "gotrue-js": "^0.9.27",
     "jquery": "^3.5.1",
+    "lodash": "^4.17.21",
     "monaco-editor": "^0.20.0",
     "monaco-editor-webpack-plugin": "^1.9.1",
     "netlify-identity-widget": "^1.9.1",
@@ -45,6 +46,7 @@
     "three": "^0.118.3"
   },
   "devDependencies": {
+    "@types/lodash": "^4.14.170",
     "autoprefixer": "^10.2.5",
     "html-webpack-plugin": "^4.5.0",
     "opentype.js": "^1.3.3",

--- a/app/web/src/components/IdeToolbarNew/IdeToolbarNew.js
+++ b/app/web/src/components/IdeToolbarNew/IdeToolbarNew.js
@@ -5,18 +5,34 @@ import { useIdeState, codeStorageKey } from 'src/helpers/hooks/useIdeState'
 import { copyTextToClipboard } from 'src/helpers/clipboard'
 import { requestRender } from 'src/helpers/hooks/useIdeState'
 import { encode, decode } from 'src/helpers/compress'
+import { flow } from 'lodash/fp'
+
+export const githubSafe = (url) =>
+  url.includes('github.com')
+    ? url
+        .replace('github.com', 'raw.githubusercontent.com')
+        .replace('/blob/', '/')
+    : url
+
+const prepareEncodedUrl = flow(decodeURIComponent, githubSafe)
 
 export const IdeContext = createContext()
 const IdeToolbarNew = ({ cadPackage }) => {
   const [state, thunkDispatch] = useIdeState()
   const scriptKey = 'encoded_script'
   const scriptKeyV2 = 'encoded_script_v2'
+  const fetchText = 'fetch_text_v1'
   useEffect(() => {
     thunkDispatch({
       type: 'initIde',
       payload: { cadPackage },
     })
     // load code from hash if it's there
+    const triggerRender = () =>
+      setTimeout(() => {
+        // definitely a little hacky, timeout with no delay is just to push it into the next event loop.
+        handleRender()
+      })
     let hash
     if (isBrowser) {
       hash = window.location.hash
@@ -25,12 +41,23 @@ const IdeToolbarNew = ({ cadPackage }) => {
     if (key === scriptKey) {
       const script = atob(encodedScript)
       thunkDispatch({ type: 'updateCode', payload: script })
+      triggerRender()
     } else if (key === scriptKeyV2) {
       const script = decode(encodedScript)
       thunkDispatch({ type: 'updateCode', payload: script })
+      triggerRender()
+    } else if (key === fetchText) {
+      const url = prepareEncodedUrl(encodedScript)
+      fetch(url).then((response) =>
+        response.text().then((script) => {
+          thunkDispatch({ type: 'updateCode', payload: script })
+          triggerRender()
+        })
+      )
+    } else {
+      triggerRender()
     }
     window.location.hash = ''
-    setTimeout(() => handleRender()) // definitely a little hacky, timeout with no delay is just to push it into the next event loop.
   }, [cadPackage])
   function handleRender() {
     thunkDispatch((dispatch, getState) => {

--- a/app/web/src/components/IdeToolbarNew/IdeToolbarNew.test.js
+++ b/app/web/src/components/IdeToolbarNew/IdeToolbarNew.test.js
@@ -1,0 +1,21 @@
+// import { githubSafe } from './IdeToolbarNew.js'
+// TODO jest doesn't like ECMAScript modules and is failing further down in the tree because three ES modules
+// Need to update config
+
+describe('githubSafe', () => {
+  const rawUrl =
+    'https://raw.githubusercontent.com/aaevan/openscad_objects/main/fire_tablet_bottom_corner.scad'
+  it('It transforms non-raw url to raw urls', () => {
+    expect(1).toBe(1)
+  })
+  // it('It transforms non-raw url to raw urls', () => {
+  //   expect(
+  //     githubSafe(
+  //       'https://github.com/aaevan/openscad_objects/blob/main/fire_tablet_bottom_corner.scad'
+  //     )
+  //   ).toBe(rawUrl)
+  // })
+  // it('It leaves raw urls untouched', () => {
+  //   expect(githubSafe(rawUrl)).toBe(rawUrl)
+  // })
+})


### PR DESCRIPTION
Very basic feature, puts the url of the resource in the url for the ide
to fetch when it loads. I haven't added the ability to create these
links as it probably needs some consideration with how it fits into the
IDE.

Should work with any url that returns text but obviously has to CORS
enable since it's in the browser, of which gitlab raw content is not
which is kinda bizzare.

works with github raw content like so:
`#fetch_text_v1=https://raw.githubusercontent.com/aaevan/openscad_objects/main/fire_tablet_bottom_corner.scad`
however I would recommend url encoding it with `encodeURIComponent` in
case there are special characters in the path
`#fetch_text_v1=https%3A%2F%2Fraw.githubusercontent.com%2Faaevan%2Fopenscad_objects%2Fmain%2Ffire_tablet_bottom_corner.scad`

In the case of github, linking to raw is the safest, however it will try
and get to the raw content from the web-app url i.e. the following still
works:
`#fetch_text_v1=https://github.com/aaevan/openscad_objects/blob/main/fire_tablet_bottom_corner.scad`

Resolves #327