### PR TITLE
Add stl download for OpenSCAD and CadQuery IDEs

### DIFF
--- a/app/api/src/docker/openscad/runScad.js
+++ b/app/api/src/docker/openscad/runScad.js
@@ -35,14 +35,15 @@ module.exports.runScad = async ({
 
 module.exports.stlExport = async ({ file } = {}) => {
   const tempFile = await makeFile(file, '.scad', nanoid)
+  const fullPath = `/tmp/${tempFile}/output.stl`
 
   try {
-    const result = await runCommand(
-      `openscad -o /tmp/${tempFile}/output.stl /tmp/${tempFile}/main.scad`,
-      300000 // lambda will time out before this, we might need to look at background jobs if we do git integration stl generation
+    const consoleMessage = await runCommand(
+      `xvfb-run --auto-servernum --server-args "-screen 0 1024x768x24" openscad -o ${fullPath} /tmp/${tempFile}/main.scad`,
+      60000 // lambda will time out before this, we might need to look at background jobs if we do git integration stl generation
     )
-    return { result, tempFile }
+    return { consoleMessage, fullPath }
   } catch (error) {
-    return { error, tempFile }
+    return { error, fullPath }
   }
 }

--- a/app/api/src/docker/serverless.yml
+++ b/app/api/src/docker/serverless.yml
@@ -63,18 +63,21 @@ functions:
     timeout: 25
     environment:
       BUCKET: cad-preview-bucket-prod-001
-  # openscadstl:
-  #   image:
-  #     name: openscadimage
-  #     command:
-  #       - openscad.stl
-  #     entryPoint:
-  #       - '/entrypoint.sh'
-  #   events:
-  #     - http:
-  #         path: openscad/stl
-  #         method: post
-  #   timeout: 30
+  openscadstl:
+    image:
+      name: openscadimage
+      command:
+        - openscad.stl
+      entryPoint:
+        - '/entrypoint.sh'
+    events:
+      - http:
+          path: openscad/stl
+          method: post
+          cors: true
+    timeout: 30
+    environment:
+      BUCKET: cad-preview-bucket-prod-001
   cadquerystl:
     image:
       name: cadqueryimage

--- a/app/web/package.json
+++ b/app/web/package.json
@@ -20,6 +20,7 @@
     "@redwoodjs/forms": "^0.31.0",
     "@redwoodjs/router": "^0.31.0",
     "@redwoodjs/web": "^0.31.0",
+    "browser-fs-access": "^0.17.2",
     "cloudinary-react": "^1.6.7",
     "controlkit": "^0.1.9",
     "get-active-classes": "^0.0.11",

--- a/app/web/src/components/IdeContainer/IdeContainer.js
+++ b/app/web/src/components/IdeContainer/IdeContainer.js
@@ -29,7 +29,7 @@ const IdeContainer = () => {
       })
       thunkDispatch((dispatch, getState) => {
         const state = getState()
-        if (state.ideType === 'openScad') {
+        if (['png', 'INIT'].includes(state.objectData?.type)) {
           dispatch({ type: 'setLoading' })
           requestRender({
             state,

--- a/app/web/src/helpers/cadPackages/common.js
+++ b/app/web/src/helpers/cadPackages/common.js
@@ -1,3 +1,40 @@
+import { STLLoader } from 'three/examples/jsm/loaders/STLLoader'
+
 export const lambdaBaseURL =
   process.env.CAD_LAMBDA_BASE_URL ||
   'https://2inlbple1b.execute-api.us-east-1.amazonaws.com/prod2'
+
+export const stlToGeometry = (url) =>
+  new Promise((resolve, reject) => {
+    new STLLoader().load(url, resolve, null, reject)
+  })
+
+export function createHealthyResponse({ date, data, consoleMessage, type }) {
+  return {
+    status: 'healthy',
+    objectData: {
+      type,
+      data: data,
+    },
+    message: {
+      type: 'message',
+      message: consoleMessage,
+      time: date,
+    },
+  }
+}
+
+export function createUnhealthyResponse(date, message = 'network issue') {
+  // TODO handle errors better
+  // I think we should display something overlayed on the viewer window something like "network issue try again"
+  // and in future I think we need timeouts differently as they maybe from a user trying to render something too complex
+  // or something with minkowski in it :/ either way something like "render timed out, try again or here are tips to reduce part complexity" with a link talking about $fn and minkowski etc
+  return {
+    status: 'error',
+    message: {
+      type: 'error',
+      message,
+      time: date,
+    },
+  }
+}

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -3097,6 +3097,11 @@
   resolved "https://registry.yarnpkg.com/@types/line-column/-/line-column-1.0.0.tgz#fa5a59c21e885fef3739a273b43dacf55b63437f"
   integrity sha512-wbw+IDRw/xY/RGy+BL6f4Eey4jsUgHQrMuA4Qj0CSG3x/7C2Oc57pmRoM2z3M4DkylWRz+G1pfX06sCXQm0J+w==
 
+"@types/lodash@^4.14.170":
+  version "4.14.170"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.170.tgz#0d67711d4bf7f4ca5147e9091b847479b87925d6"
+  integrity sha512-bpcvu/MKHHeYX+qeEN8GE7DIravODWdACVA1ctevD8CN24RhPZIKMn9ntfAsrvLfSX3cR5RrBKAbYm9bGs0A+Q==
+
 "@types/long@^4.0.0":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.1.tgz#459c65fa1867dafe6a8f322c4c51695663cc55e9"
@@ -4821,6 +4826,11 @@ brorand@^1.0.1, brorand@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
   integrity sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=
+
+browser-fs-access@^0.17.2:
+  version "0.17.2"
+  resolved "https://registry.yarnpkg.com/browser-fs-access/-/browser-fs-access-0.17.2.tgz#6debfe35ebce77a1eecca7822a449c740a8de9db"
+  integrity sha512-z3H37rU3fmKkGJ1r09v3hAwByUI0vYIh8a7LsUaQnnMxdVUJm1UzsffvNK6Qnvk9jGqvY7uiX2DPu4BZXavcWA==
 
 browser-process-hrtime@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Everything always takes longer that expected. Few things to note.
- in the browser I'm doing less checks for `ideType === 'openScad'` and now more data type === geometry or png, since now openscad can display 3d in preview as well.
- When a user wants to download an openscad stl, than we might as well display it properly in the browser instead of just images since we're already doing so for CadQuery.
- Also in terms of caching the openscad preview also checks if there is an stl cached not only images since if a user has already downloaded that shape, might as well give them the better experience of full 3d

Some things that are not ideal:
- There is a difference in the coord system between the OpenScad images and the 3d result, so it suddenly jumps when it changes from image to 3d, it's bearable but not great
- The stl generation for OpenSCAD does not log anything to stdout which means I have nothing to show in the console. I'm not sure why at this point

Resolves #330.