### PR TITLE
Make sure the code-init is robust when local storage is empty

### DIFF
--- a/app/web/src/components/IdeEditor/IdeEditor.js
+++ b/app/web/src/components/IdeEditor/IdeEditor.js
@@ -1,6 +1,6 @@
 import { useContext, Suspense, lazy } from 'react'
 import { IdeContext } from 'src/components/IdeToolbarNew'
-import { codeStorageKey } from 'src/helpers/hooks/useIdeState'
+import { makeCodeStoreKey } from 'src/helpers/hooks/useIdeState'
 import { requestRender } from 'src/helpers/hooks/useIdeState'
 const Editor = lazy(() => import('@monaco-editor/react'))
 
@@ -38,7 +38,7 @@ const IdeEditor = () => {
           camera: state.camera,
         })
       })
-      localStorage.setItem(codeStorageKey, state.code)
+      localStorage.setItem(makeCodeStoreKey(state.ideType), state.code)
     }
   }
   const loading = (

--- a/app/web/src/components/IdeToolbarNew/IdeToolbarNew.js
+++ b/app/web/src/components/IdeToolbarNew/IdeToolbarNew.js
@@ -1,7 +1,7 @@
 import { createContext, useEffect } from 'react'
 import IdeContainer from 'src/components/IdeContainer'
 import { isBrowser } from '@redwoodjs/prerender/browserUtils'
-import { useIdeState, codeStorageKey } from 'src/helpers/hooks/useIdeState'
+import { useIdeState, makeCodeStoreKey } from 'src/helpers/hooks/useIdeState'
 import { copyTextToClipboard } from 'src/helpers/clipboard'
 import { requestRender } from 'src/helpers/hooks/useIdeState'
 import { encode, decode } from 'src/helpers/compress'
@@ -74,7 +74,7 @@ const IdeToolbarNew = ({ cadPackage }) => {
         camera: state.camera,
       })
     })
-    localStorage.setItem(codeStorageKey, state.code)
+    localStorage.setItem(makeCodeStoreKey(state.ideType), state.code)
   }
   function handleMakeLink() {
     if (isBrowser) {
@@ -83,8 +83,8 @@ const IdeToolbarNew = ({ cadPackage }) => {
       copyTextToClipboard(window.location.href)
     }
   }
-  const PullTitleFromFirstLine = (code) => {
-    const firstLine = code.split('\n').filter(identity)[0]
+  const PullTitleFromFirstLine = (code = '') => {
+    const firstLine = code.split('\n').filter(identity)[0] || ''
     if (!(firstLine.startsWith('//') || firstLine.startsWith('#'))) {
       return 'object.stl'
     }

--- a/app/web/src/helpers/cadPackages/common.js
+++ b/app/web/src/helpers/cadPackages/common.js
@@ -2,7 +2,7 @@ import { STLLoader } from 'three/examples/jsm/loaders/STLLoader'
 
 export const lambdaBaseURL =
   process.env.CAD_LAMBDA_BASE_URL ||
-  'https://2inlbple1b.execute-api.us-east-1.amazonaws.com/prod2'
+  'https://oxt2p7ddgj.execute-api.us-east-1.amazonaws.com/prod'
 
 export const stlToGeometry = (url) =>
   new Promise((resolve, reject) => {

--- a/app/web/src/helpers/hooks/useIdeState.js
+++ b/app/web/src/helpers/hooks/useIdeState.js
@@ -44,11 +44,12 @@ show_object(result)
 `,
 }
 
-export const codeStorageKey = 'Last-editor-code'
+const codeStorageKey = 'Last-editor-code'
+export const makeCodeStoreKey = (ideType) => `${codeStorageKey}-${ideType}`
 let mutableState = null
 
 export const useIdeState = () => {
-  const code = localStorage.getItem(codeStorageKey) || initCodeMap.openscad
+  const code = ''
   const initialState = {
     ideType: 'INIT',
     consoleMessages: [
@@ -78,7 +79,10 @@ export const useIdeState = () => {
       case 'initIde':
         return {
           ...state,
-          code: initCodeMap[payload.cadPackage] || initCodeMap.openscad,
+          code:
+            localStorage.getItem(makeCodeStoreKey(payload.cadPackage)) ||
+            initCodeMap[payload.cadPackage] ||
+            '',
           ideType: payload.cadPackage,
         }
       case 'updateCode':


### PR DESCRIPTION
We put draft code into local storage so user's don't lose their code if they click away in draft, but because of this a bug had creeped in that would cause error if it was the user's first time on the site, I need to remember to clear my local storage when doing regression testing.

Even though it was local storage that cause the bug, this code wasn't working either, even since we introduced CadQuery because it needs to deal with two cade package which it wasn't doing so that's fixed too now.