### PR TITLE
Updated Dockerfile for newer version of CadQuery and cq-cli

### DIFF
--- a/app/api/src/docker/cadquery/Dockerfile
+++ b/app/api/src/docker/cadquery/Dockerfile
@@ -36,7 +36,9 @@ RUN npm install
 
 
 # Get the distribution copy of cq-cli
-RUN wget https://github.com/CadQuery/cq-cli/releases/download/v2.1.0/cq-cli-Linux-x86_64.zip
+RUN wget https://github.com/CadQuery/cq-cli/releases/download/v2.2-beta.1/cq-cli-Linux-x86_64.zip
+# Comment the entry above out and uncomment the one below to revert to the stable release
+# RUN wget https://github.com/CadQuery/cq-cli/releases/download/v2.1.0/cq-cli-Linux-x86_64.zip
 RUN unzip cq-cli-Linux-x86_64.zip
 
 RUN chmod +x cq-cli/cq-cli


### PR DESCRIPTION
The link in the Dockerfile has been changed to point to release v2.2-beta.1, which is a contrived release system that will allow us to update cq-cli (and thus CadQuery) while not doing a rolling release with master. The next beta release (when/if needed) will be *-beta.2 and so on.

I have tested this version of cq-cli locally in the following use cases, and each one worked.

1. The braille example, to generate an STL. I was able to import and slice the resulting file fine.
2. An assembly example using `Assembly.toCompound()` to convert a CQ assembly to a compound so that it could be exported to STL. If CadHub switches to STEP files we probably won't need this, but for now it's a decent work-around.
3. The lid example from CadQuery's Discord. This version has the functions available to have the provided solution work. I exported the lid to STL without issue.

I left the stable version `RUN` line in, but commented it out. My thought was to make it easier to revert back to it if a major issue is discovered with this beta release.