### PR TITLE
Updated for cq-cli beta 2 of v2.2, which adds the ability to adjust STL quality

### DIFF
--- a/app/api/src/docker/cadquery/Dockerfile
+++ b/app/api/src/docker/cadquery/Dockerfile
@@ -37,7 +37,7 @@ RUN npm install
 
 # Get the distribution copy of cq-cli
 RUN apt-get install -y libglew2.1
-RUN wget https://github.com/CadQuery/cq-cli/releases/download/v2.2-beta.1/cq-cli-Linux-x86_64.zip
+RUN wget https://github.com/CadQuery/cq-cli/releases/download/v2.2-beta.2/cq-cli-Linux-x86_64.zip
 # Comment the entry above out and uncomment the one below to revert to the stable release
 # RUN wget https://github.com/CadQuery/cq-cli/releases/download/v2.1.0/cq-cli-Linux-x86_64.zip
 RUN unzip cq-cli-Linux-x86_64.zip


### PR DESCRIPTION
Simple update to use the new beta release of cq-cli that allows adjusting STL quality. Example #8 [here](https://github.com/CadQuery/cq-cli#examples) shows how to use it. A value of 0.3 for the linear and angular deflection worked well for the braille generator and cut the file size from almost 40 MB down to 5.3 MB, but was not tested on a wide range of models.