### PR TITLE
Add gizmo and edges

### DIFF
--- a/app/web/src/components/IdeViewer/IdeViewer.tsx
+++ b/app/web/src/components/IdeViewer/IdeViewer.tsx
@@ -1,7 +1,14 @@
 import { useIdeContext } from 'src/helpers/hooks/useIdeContext'
+import * as THREE from 'three'
 import { useRef, useState, useEffect } from 'react'
 import { Canvas, useThree } from '@react-three/fiber'
-import { PerspectiveCamera, useEdgeSplit, GizmoHelper, GizmoViewport, OrbitControls } from '@react-three/drei'
+import {
+  PerspectiveCamera,
+  useEdgeSplit,
+  GizmoHelper,
+  GizmoViewport,
+  OrbitControls,
+} from '@react-three/drei'
 import { Vector3 } from 'three'
 import { requestRender } from 'src/helpers/hooks/useIdeState'
 import texture from './dullFrontLitMetal.png'
@@ -14,6 +21,11 @@ const colorMap = loader.load(texture)
 
 function Asset({ geometry: incomingGeo }) {
   const mesh = useEdgeSplit((12 * Math.PI) / 180, true)
+  const edges = React.useMemo(
+    () =>
+      incomingGeo.length ? null : new THREE.EdgesGeometry(incomingGeo, 15),
+    [incomingGeo]
+  )
   if (!incomingGeo) return null
 
   if (incomingGeo.length)
@@ -22,9 +34,14 @@ function Asset({ geometry: incomingGeo }) {
     ))
 
   return (
-    <mesh ref={mesh} scale={[1, 1, 1]} geometry={incomingGeo}>
-      <meshStandardMaterial map={colorMap} color="#F472B6" />
-    </mesh>
+    <group dispose={null}>
+      <mesh ref={mesh} scale={[1, 1, 1]} geometry={incomingGeo}>
+        <meshStandardMaterial map={colorMap} color="#F472B6" />
+      </mesh>
+      <lineSegments geometry={edges} renderOrder={100} opac>
+        <lineBasicMaterial color="#555588" opacity={0.5} transparent />
+      </lineSegments>
+    </group>
   )
 }
 
@@ -99,11 +116,7 @@ function Controls({ onCameraChange, onDragStart, onInit }) {
   }, [camera, controls])
 
   return (
-    <OrbitControls
-      makeDefault
-      ref={controls}
-      args={[camera, gl.domElement]}
-    />
+    <OrbitControls makeDefault ref={controls} args={[camera, gl.domElement]} />
   )
 }
 
@@ -207,18 +220,11 @@ const IdeViewer = ({ Loading }) => {
             material-transparent
             rotation-x={Math.PI / 2}
           />
-          <GizmoHelper
-            alignment={'top-left'}
-            margin={[80, 80]}
-          >
-          <GizmoViewport
-            axisColors={[
-              'red',
-              'green',
-              'blue',
-            ]}
-            labelColor='black'
-          />
+          <GizmoHelper alignment={'top-left'} margin={[80, 80]}>
+            <GizmoViewport
+              axisColors={['red', 'green', 'blue']}
+              labelColor="black"
+            />
           </GizmoHelper>
           {state.objectData?.type === 'png' && (
             <>

--- a/app/web/src/components/IdeViewer/IdeViewer.tsx
+++ b/app/web/src/components/IdeViewer/IdeViewer.tsx
@@ -4,11 +4,11 @@ import { useRef, useState, useEffect } from 'react'
 import { Canvas, useThree } from '@react-three/fiber'
 import {
   PerspectiveCamera,
-  useEdgeSplit,
   GizmoHelper,
   GizmoViewport,
   OrbitControls,
 } from '@react-three/drei'
+import { useEdgeSplit } from 'src/helpers/hooks/useEdegeSplit'
 import { Vector3 } from 'three'
 import { requestRender } from 'src/helpers/hooks/useIdeState'
 import texture from './dullFrontLitMetal.png'
@@ -19,11 +19,13 @@ import DelayedPingAnimation from 'src/components/DelayedPingAnimation/DelayedPin
 const loader = new TextureLoader()
 const colorMap = loader.load(texture)
 
+const thresholdAngle = 12
+
 function Asset({ geometry: incomingGeo }) {
-  const mesh = useEdgeSplit((12 * Math.PI) / 180, true)
+  const mesh = useEdgeSplit((thresholdAngle * Math.PI) / 180, true, incomingGeo)
   const edges = React.useMemo(
     () =>
-      incomingGeo.length ? null : new THREE.EdgesGeometry(incomingGeo, 15),
+      incomingGeo.length ? null : new THREE.EdgesGeometry(incomingGeo, thresholdAngle),
     [incomingGeo]
   )
   if (!incomingGeo) return null

--- a/app/web/src/components/IdeViewer/IdeViewer.tsx
+++ b/app/web/src/components/IdeViewer/IdeViewer.tsx
@@ -1,8 +1,7 @@
 import { useIdeContext } from 'src/helpers/hooks/useIdeContext'
-import { useRef, useState, useEffect, useLayoutEffect } from 'react'
-import { Canvas, extend, useFrame, useThree } from '@react-three/fiber'
-import { PerspectiveCamera, useEdgeSplit } from '@react-three/drei'
-import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls'
+import { useRef, useState, useEffect } from 'react'
+import { Canvas, useThree } from '@react-three/fiber'
+import { PerspectiveCamera, useEdgeSplit, GizmoHelper, GizmoViewport, OrbitControls } from '@react-three/drei'
 import { Vector3 } from 'three'
 import { requestRender } from 'src/helpers/hooks/useIdeState'
 import texture from './dullFrontLitMetal.png'
@@ -12,8 +11,6 @@ import DelayedPingAnimation from 'src/components/DelayedPingAnimation/DelayedPin
 
 const loader = new TextureLoader()
 const colorMap = loader.load(texture)
-
-extend({ OrbitControls })
 
 function Asset({ geometry: incomingGeo }) {
   const mesh = useEdgeSplit((12 * Math.PI) / 180, true)
@@ -46,9 +43,6 @@ function Controls({ onCameraChange, onDragStart, onInit }) {
     camera.fov = 22.5 // matches default openscad fov
     camera.updateProjectionMatrix()
 
-    // Order matters with Euler rotations
-    // We want it to rotate around the z or vertical axis first then the x axis to match openscad
-    // in Three.js Y is the vertical axis (Z for openscad)
     camera.rotation._order = 'ZYX'
     const getRotations = (): number[] => {
       const { x, y, z } = camera?.rotation || {}
@@ -104,12 +98,11 @@ function Controls({ onCameraChange, onDragStart, onInit }) {
     }
   }, [camera, controls])
 
-  useFrame(() => controls.current?.update())
   return (
-    <orbitControls
+    <OrbitControls
+      makeDefault
       ref={controls}
       args={[camera, gl.domElement]}
-      rotateSpeed={0.5}
     />
   )
 }
@@ -214,6 +207,19 @@ const IdeViewer = ({ Loading }) => {
             material-transparent
             rotation-x={Math.PI / 2}
           />
+          <GizmoHelper
+            alignment={'top-left'}
+            margin={[80, 80]}
+          >
+          <GizmoViewport
+            axisColors={[
+              'red',
+              'green',
+              'blue',
+            ]}
+            labelColor='black'
+          />
+          </GizmoHelper>
           {state.objectData?.type === 'png' && (
             <>
               <Sphere position={[0, 0, 0]} color={pink400} />

--- a/app/web/src/helpers/hooks/useEdegeSplit.ts
+++ b/app/web/src/helpers/hooks/useEdegeSplit.ts
@@ -1,0 +1,30 @@
+// This code has been copied from https://github.com/pmndrs/drei/blob/master/src/core/useEdgeSplit.tsx
+// but modified to allow for updating geometry with `dependantGeometry`
+
+import * as React from 'react'
+import * as THREE from 'three'
+import { EdgeSplitModifier } from 'three-stdlib'
+
+export function useEdgeSplit(cutOffAngle: number, tryKeepNormals: boolean = true, dependantGeometry?: any) {
+  const ref = React.useRef<THREE.Mesh>()
+  const original = React.useRef<THREE.BufferGeometry>()
+  const modifier = React.useRef<EdgeSplitModifier>()
+
+  React.useEffect(() => {
+    if (!original.current && ref.current) {
+      original.current = ref.current.geometry.clone()
+      modifier.current = new EdgeSplitModifier()
+    }
+  }, [dependantGeometry])
+
+  React.useEffect(() => {
+    if (original.current && ref.current && modifier.current) {
+      const modifiedGeometry = modifier.current.modify(original.current, cutOffAngle, tryKeepNormals)
+      modifiedGeometry.computeVertexNormals()
+
+      ref.current.geometry = modifiedGeometry
+    }
+  }, [cutOffAngle, tryKeepNormals, dependantGeometry])
+
+  return ref
+}


### PR DESCRIPTION
Add edges to the models with helps solve the issue of surfaces blending together and should resolve #383 

Also added a gizmo, there seems to be an issue with the animation/camera path, not sure if its my setup or a bug (asked here https://github.com/pmndrs/drei/issues/465#issuecomment-895812677) but I think its worth adding anyway since at the end of the day it still works for snapping the camera to axis.

@franknoirot something to keep in mind, I never gave a great deal of thought to the pink color of the models, we've recently added a grid, and this adds edges and the colors of the Gizmo.
![image](https://user-images.githubusercontent.com/29681384/128853636-1c514300-14be-480a-a22f-8e90b8006fda.png)
I think it looks okay . . . but it could get worse should we need to add more.