### PR TITLE
Fix project renaming in safari

### DIFF
--- a/app/web/src/components/EditableProjecTitle/EditableProjecTitle.tsx
+++ b/app/web/src/components/EditableProjecTitle/EditableProjecTitle.tsx
@@ -76,12 +76,10 @@ const EditableProjectTitle = ({
               value={newTitle}
               onChange={onTitleChange}
               ref={inputRef}
-              onBlur={({ relatedTarget }) => {
-                if (relatedTarget?.id !== 'rename-button') {
-                  setInEditMode(false)
-                  setNewTitle(projectTitle)
-                }
-              }}
+              onBlur={() => setTimeout(() => {
+                setInEditMode(false)
+                setNewTitle(projectTitle)
+              }, 300)}
             />
           </span>
           <div className="flex items-center h-full">


### PR DESCRIPTION
Resolves #434

basically the flow i was going for was that if you loose focus the name is reverted.

https://user-images.githubusercontent.com/29681384/129016133-98391d12-331d-4a83-ad82-5753831202a4.mov

but because clicking the rename button is also loosing focus but onblur is called before the button's on click handler i was using the `relatedTarget` event property to tell if it was just loosing focus or loosing focus because the button was pressed, but safari doesn't seem to support that property so using a good old time out instead to allow the button handle a chance to fire, and since it redirects the user anyway the fact that `setNewTitle` etc is still called is not a problem.