### PR TITLE
parse as number even for text if numeric string

### DIFF
--- a/app/web/src/helpers/cadPackages/jsCad/jscadParams.ts
+++ b/app/web/src/helpers/cadPackages/jsCad/jscadParams.ts
@@ -199,9 +199,11 @@ function getParams(target: HTMLElement): RawCustomizerParams {
     if (
       numeric[elem.getAttribute('type')] ||
       elem.getAttribute('numeric') == '1'
-    )
+    ){
       value = parseFloat(String(value || 0))
-
+    }else if (value && typeof(value) === 'string' && /^(\d+|\d+\.\d+)$/.test(value.trim())){
+      value = parseFloat(String(value || 0))
+    }
     if (elem.type == 'radio' && !elem.checked) return // skip if not checked radio button
 
     params[name] = value


### PR DESCRIPTION
Sometimes a default type for parameter is textual, but code expects number.

This breaks calls to jscad built-in functions in horrible ways as calculations with a string generate NaN.

It is less of a problem if code expects text (much less the case) and gets number.

