### PR TITLE
EdgeSplit not flushing out old geometry

### DIFF
--- a/app/web/src/helpers/hooks/useEdegeSplit.ts
+++ b/app/web/src/helpers/hooks/useEdegeSplit.ts
@@ -19,6 +19,11 @@ export function useEdgeSplit(
       original.current = ref.current.geometry.clone()
       modifier.current = new EdgeSplitModifier()
     }
+  }, [])
+
+  React.useEffect(() => {
+    original.current = dependantGeometry.clone()
+    modifier.current = new EdgeSplitModifier()
   }, [dependantGeometry])
 
   React.useEffect(() => {


### PR DESCRIPTION
Mostly effecting CQ, changing the script and updating leaves a ghost of
the old geometry in the viewer

Resolves #459