### PR TITLE
Share popover color tweaks

### DIFF
--- a/app/.env.example
+++ b/app/.env.example
@@ -1,0 +1,2 @@
+# DATABASE_URL=file:./dev.db
+# BINARY_TARGET=native

--- a/app/.env.example
+++ b/app/.env.example
@@ -1,2 +1,0 @@
-# DATABASE_URL=file:./dev.db
-# BINARY_TARGET=native

--- a/app/web/src/components/EncodedUrl/ExternalScript.tsx
+++ b/app/web/src/components/EncodedUrl/ExternalScript.tsx
@@ -53,7 +53,7 @@ const ExternalScript = () => {
   }
   return (
     <div className="p-4">
-      <p className="text-sm pb-4">
+      <p className="text-sm pb-4 border-b border-gray-700">
         Paste an external url containing a {cadName} script to generate a new
         CadHub url for this resource.{' '}
         <OutBound
@@ -66,9 +66,9 @@ const ExternalScript = () => {
       </p>
       {['INIT', 'ERROR'].includes(asyncState) && (
         <>
-          <p>Paste url</p>
+          <p className="mt-4">Paste url</p>
           <input
-            className="p-1 text-xs rounded border border-gray-700 w-full"
+            className="p-1 text-xs border border-ch-purple-450 w-full"
             value={rawUrl}
             onChange={onChange}
             onPaste={onPaste}
@@ -91,23 +91,23 @@ const ExternalScript = () => {
           <input
             value={makeExternalUrl(rawUrl).replace(/^.+:\/\//g, '')}
             readOnly
-            className="p-1 mt-4 text-xs rounded-t border border-gray-700 w-full"
+            className="py-1 px-2 mt-4 text-xs border border-ch-purple-450 w-full"
           />
           <button
-            className="w-full bg-gray-700 py-1 rounded-b text-gray-300"
+            className="w-full bg-ch-purple-450 hover:bg-ch-purple-400 py-1 text-gray-300"
             onClick={() => copyTextToClipboard(makeExternalUrl(rawUrl))}
           >
             Copy URL
           </button>
           <div className="flex flex-col gap-2 pt-2">
             <button
-              className="bg-gray-500 p-1 px-2 rounded text-gray-300"
+              className="bg-gray-500 hover:bg-gray-600 p-1 px-2 text-gray-200"
               onClick={onCopyRender}
             >
               Copy &amp; Render
             </button>
             <button
-              className="bg-gray-500 p-1 px-2 rounded text-gray-300"
+              className="bg-gray-500 hover:bg-gray-600 p-1 px-2 text-gray-200"
               onClick={() => {
                 setAsyncState('INIT')
                 setRawUrl('')

--- a/app/web/src/components/EncodedUrl/FullScriptEncoding.tsx
+++ b/app/web/src/components/EncodedUrl/FullScriptEncoding.tsx
@@ -13,10 +13,10 @@ const FullScriptEncoding = () => {
       <input
         value={encodedLink.replace(/^.+:\/\//g, '')}
         readOnly
-        className="p-1 mt-4 text-xs rounded-t border border-gray-700 w-full"
+        className="py-1 px-2 mt-4 text-xs border border-ch-purple-450 w-full"
       />
       <button
-        className="w-full bg-gray-700 py-1 rounded-b text-gray-300"
+        className="w-full bg-ch-purple-450 hover:bg-ch-purple-400 py-1 rounded-b text-gray-300"
         onClick={() => copyTextToClipboard(encodedLink)}
       >
         Copy URL

--- a/app/web/src/components/EncodedUrl/FullScriptEncoding.tsx
+++ b/app/web/src/components/EncodedUrl/FullScriptEncoding.tsx
@@ -16,7 +16,7 @@ const FullScriptEncoding = () => {
         className="py-1 px-2 mt-4 text-xs border border-ch-purple-450 w-full"
       />
       <button
-        className="w-full bg-ch-purple-450 hover:bg-ch-purple-400 py-1 rounded-b text-gray-300"
+        className="w-full bg-ch-purple-450 hover:bg-ch-purple-400 py-1 text-gray-300"
         onClick={() => copyTextToClipboard(encodedLink)}
       >
         Copy URL

--- a/app/web/src/components/IdeHeader/IdeHeader.tsx
+++ b/app/web/src/components/IdeHeader/IdeHeader.tsx
@@ -152,8 +152,8 @@ const IdeHeader = ({
                 {open && (
                   <Popover.Panel className="absolute z-10 mt-4 right-0">
                     <Tabs
-                      className="bg-gray-300 rounded-md shadow-md overflow-hidden text-gray-700"
-                      selectedTabClassName="bg-gray-200"
+                      className="bg-ch-purple-gray-200 rounded-md shadow-md overflow-hidden text-gray-700"
+                      selectedTabClassName="bg-ch-gray-700 text-white"
                     >
                       <TabPanel>
                         <FullScriptEncoding />

--- a/app/web/tailwind.config.js
+++ b/app/web/tailwind.config.js
@@ -27,8 +27,12 @@ module.exports = {
         },
         'ch-purple': {
           400: '#3B0480',
+          450: '#671BC6',
           500: '#8732F2',
           600: '#A663FA',
+        },
+        'ch-purple-gray': {
+          200: '#DBDBEC',
         },
         'ch-blue': {
           600: '#79B2F8',


### PR DESCRIPTION
Got the Share popover styled to match Figma closer. Sorry should've done this a week ago.

[Link to the Share popover in Figma](https://www.figma.com/file/VUh53RdncjZ7NuFYj0RGB9/CadHub?node-id=1002%3A540)

## Encoded Script
<img width="510" alt="Screen Shot 2021-08-23 at 10 27 43 PM" src="https://user-images.githubusercontent.com/23481541/130546304-ce2c4065-d4ca-4239-85c8-4b3ec0588caa.png">

## External Script
![Screen Shot 2021-08-23 at 10 28 02 PM](https://user-images.githubusercontent.com/23481541/130546371-469066cf-1fe6-40e4-9377-0f8593850f4c.jpg)

I realized I hadn't designed the rollover states. I tried making them darker on hover and thought it didn't look too bad:
![Screen Shot 2021-08-23 at 10 28 09 PM](https://user-images.githubusercontent.com/23481541/130546426-f4fa8008-f285-449f-b8a5-6abad1b37bec.jpg)
