### PR TITLE
Fix generic URL for blog rss generation

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -2,7 +2,7 @@
 module.exports = {
   title: 'CadHub',
   tagline: '',
-  url: 'https://your-docusaurus-test-site.com',
+  url: 'https://learn.cadhub.xyz',
   baseUrl: '/',
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',


### PR DESCRIPTION
I wanted to read the cadhub blog from my RSS reader, but the links were not working properly.

As you can see here: https://learn.cadhub.xyz/blog/rss.xml the urls are going to https://your-docusaurus-test-site.com/blog

