### PR TITLE
Fix parameters retention/Stale customizer params

### DIFF
--- a/app/web/src/helpers/cadPackages/jsCad/jscadWorker.ts
+++ b/app/web/src/helpers/cadPackages/jsCad/jscadWorker.ts
@@ -401,12 +401,11 @@ const makeScriptWorker = ({ callback, convertToSolids }) => {
           }
         })
       }
-      if (paramsDef.length)
-        callback({
-          action: 'parameterDefinitions',
-          worker: 'main',
-          data: paramsDef,
-        })
+      callback({
+        action: 'parameterDefinitions',
+        worker: 'main',
+        data: paramsDef,
+      })
 
       runMain(params)
     },

--- a/app/web/src/helpers/hooks/useIdeState.ts
+++ b/app/web/src/helpers/hooks/useIdeState.ts
@@ -107,9 +107,7 @@ const reducer = (state: State, { type, payload }): State => {
     case 'updateCode':
       return { ...state, code: payload }
     case 'healthyRender':
-      const customizerParams: CadhubParams[] = payload?.customizerParams?.length
-        ? payload.customizerParams
-        : state.customizerParams
+      const customizerParams: CadhubParams[] = payload.customizerParams
       const currentParameters = {}
       customizerParams.forEach((param) => {
         currentParameters[param.name] =


### PR DESCRIPTION
@Irev-Dev I fixed jscad part and added 2 console.log ... 

from what I am seing issue is in state management. The worker now send new parameter definitions, but when the definitions are empty it is not cleared in customizer, so that is why customizer for another model that has none stay populated...

![image](https://user-images.githubusercontent.com/2480762/133308271-29aef8dc-5f29-435d-a110-6a95b15b7634.png)


this can easiliy be tested in jscad IDE by just removin one letter in the initial source

```js
// emtpy params def
function main({//@jscad-param
//many params in def
function main({//@jscad-params
```

feel free to commit changes directly if it  makes sense to do so