### PR TITLE
side-tray-styles-patch

### DIFF
--- a/app/web/src/components/IdeSideBar/IdeSideBar.tsx
+++ b/app/web/src/components/IdeSideBar/IdeSideBar.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { getActiveClasses } from 'get-active-classes'
 import Svg from 'src/components/Svg/Svg'
 import {
   sidebarTopConfig,
@@ -10,9 +10,11 @@ import { useIdeContext } from 'src/helpers/hooks/useIdeContext'
 function TabToggle({ item, className = '', active, onChange, onClick }) {
   return (
     <label
-      className={`tabToggle${item.disabled ? ' disabled' : ''}${
-        active ? ' active' : ''
-      } ${className}`}
+      className={getActiveClasses({
+        'bg-ch-pink-800 text-ch-pink-300 bg-opacity-30': active,
+        'text-ch-gray-550 cursor-not-allowed': item.disabled,
+        [`text-ch-gray-300 p-3 mb-1 flex justify-center ${className}`]: true,
+      })}
     >
       <input
         name="sidebar-tabs"

--- a/app/web/src/index.css
+++ b/app/web/src/index.css
@@ -32,19 +32,6 @@
 
 }
 
-@layer components {
-  .tabToggle {
-    @apply text-ch-gray-300 p-3 mb-1 flex justify-center;
-  }
-  .tabToggle.active {
-    @apply bg-ch-pink-800 text-ch-pink-300 bg-opacity-30;
-  }
-  .tabToggle.disabled {
-    @apply text-ch-gray-550 cursor-not-allowed;
-
-  }
-}
-
 .three-debug-panel-1 {
   position: fixed;
   padding-top: 300px;


### PR DESCRIPTION
Merging now because styles are currently broken. Not sure why this is different when built vs dev.

![image](https://user-images.githubusercontent.com/29681384/133880416-cacc4b2b-b1f2-4bd9-a635-0e8967378691.png)
To replicate checkout previous commit and `yarn rw build && yarn rw serve`