### PR TITLE
Show empty `KeyValue`'s if editing

### DIFF
--- a/app/web/src/components/UserProfile/userProfileConfig.tsx
+++ b/app/web/src/components/UserProfile/userProfileConfig.tsx
@@ -53,7 +53,7 @@ const ProfileKeyValue = ({
   bottom = false,
 }: ProfileKeyValueType) => {
   return (
-    user[field.name] && (
+    (user[field.name] || hasPermissionToEdit) && (
       <KeyValue
         keyName={field.name}
         edit={{


### PR DESCRIPTION
Begins #525, although more gaps in the profile validation have been found.

@Irev-Dev one interesting issue I ran into with the `Bio` Markdown editor is that when I tried to set my bio to nothing it still kept around an invisible newline character (value was `\\n` in Prisma Studio), so the bio always appeared after editing once, even after trying to delete it.

I suppose this is a vanishingly rare case though, where someone took the time to write a profile at one point but now definitely wants no bio, right? 🤷🏻‍♂️