### PR TITLE
Hide console option in view menu

### DIFF
--- a/app/web/src/components/EditorMenu/menuConfig.tsx
+++ b/app/web/src/components/EditorMenu/menuConfig.tsx
@@ -69,6 +69,16 @@ const viewMenuConfig: EditorMenuConfig = {
   disabled: false,
   items: [
     {
+      label: 'Hide console',
+      shortcut: 'ctrl+shift+c',
+      shortcutLabel: 'Ctrl Shift C',
+      Component: (props) => {
+        const { config, thunkDispatch } = props
+        config.callback = () => thunkDispatch({ type: 'setLayout', payload:{ message:{ direction: 'row',  first: 'Editor',  second: 'Viewer'}}})
+        return <DropdownItem {...props} />
+      },
+    },
+    {
       label: 'Reset layout',
       shortcut: 'ctrl+shift+r',
       shortcutLabel: 'Ctrl Shift R',


### PR DESCRIPTION
This was simplest way I could find and is fine for me. Menu item is enough, no ned for a button on console pane.