### PR TITLE
use project title for download title

### DIFF
--- a/app/web/src/components/EditorMenu/menuConfig.tsx
+++ b/app/web/src/components/EditorMenu/menuConfig.tsx
@@ -5,6 +5,7 @@ import { useSaveCode } from 'src/components/IdeWrapper/useSaveCode'
 import { DropdownItem } from './Dropdowns'
 import { useShortcutsModalContext } from './AllShortcutsModal'
 import type { State } from 'src/helpers/hooks/useIdeState'
+import { useIdeContext } from 'src/helpers/hooks/useIdeContext'
 
 export function cmdOrCtrl() {
   return /(Mac|iPhone|iPod|iPad)/i.test(navigator.platform) ? '⌘' : 'Ctrl'
@@ -40,12 +41,13 @@ const fileMenuConfig: EditorMenuConfig = {
       shortcutLabel: cmdOrCtrl() + ' Shift D',
       Component: (props) => {
         const { state, thunkDispatch, config } = props
+        const {project} = useIdeContext()
         const handleStlDownload = makeStlDownloadHandler({
           type: state.objectData?.type,
           ideType: state.ideType,
           geometry: state.objectData?.data,
           quality: state.objectData?.quality,
-          fileName: PullTitleFromFirstLine(state.code || ''),
+          fileName: project? `${ project.title}.stl` : PullTitleFromFirstLine(state.code || ''),
           thunkDispatch,
         })
 


### PR DESCRIPTION
Now the downloaded stl file has <project-title>.stl as a name. In draft view where there is no project it uses the old file's first row naming solution.