### PR TITLE
jscad parameters default values and float type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
+.history
 .DS_Store
 .env
 .netlify

--- a/app/web/src/helpers/cadPackages/jsCad/jscadParams.ts
+++ b/app/web/src/helpers/cadPackages/jsCad/jscadParams.ts
@@ -8,6 +8,7 @@ type JscadTypeNames =
   | 'group'
   | 'text'
   | 'int'
+  | 'float'
   | 'number'
   | 'slider'
   | 'email'
@@ -37,7 +38,7 @@ interface JscadTextParam extends JscadParamBase {
   maxLength: number
 }
 interface JscadIntNumberSliderParam extends JscadParamBase {
-  type: 'int' | 'number' | 'slider'
+  type: 'int' | 'number' | 'float' | 'slider'
   initial: number
   min?: number
   max?: number
@@ -93,6 +94,7 @@ export function jsCadToCadhubParams(input: JsCadParams[]): CadhubParams[] {
       switch (param.type) {
         case 'slider':
         case 'number':
+        case 'float':
         case 'int':
           return {
             type: 'number',

--- a/app/web/src/helpers/cadPackages/jsCad/jscadWorker.ts
+++ b/app/web/src/helpers/cadPackages/jsCad/jscadWorker.ts
@@ -315,9 +315,12 @@ function parseDef(code, line) {
 }
 
 const makeScriptWorker = ({ callback, convertToSolids }) => {
-  let onInit, main, scriptStats, entities
+  let onInit, main, scriptStats, entities, lastParamsDef
 
   function runMain(params = {}) {
+    if(lastParamsDef) lastParamsDef.forEach(def=>{
+      if(!(def.name in params) && 'initial' in def) params[def.name] = def.initial
+    })
     let time = Date.now()
     let solids
     const transfer = []
@@ -397,10 +400,12 @@ const makeScriptWorker = ({ callback, convertToSolids }) => {
           if (idx === -1) {
             paramsDef.push(p)
           } else {
-            paramsDef.splice(idx, 1, p)
+            paramsDef[idx] = p
           }
         })
       }
+      console.log('paramsDef', paramsDef)
+      lastParamsDef = paramsDef
       callback({
         action: 'parameterDefinitions',
         worker: 'main',


### PR DESCRIPTION
`float` type was missing from jscad params parser, so even the basic getParameterDefinitions example from jscad docs did not work.

Also parser was sending empty parameters object when customizer is closed, and it is wrong to do so if the parameters have a defined initial value.

