### PR TITLE
new jscad default color

### DIFF
--- a/app/web/src/helpers/cadPackages/jsCad/jsCadController.tsx
+++ b/app/web/src/helpers/cadPackages/jsCad/jsCadController.tsx
@@ -20,7 +20,7 @@ import TheWorker from 'worker-loader!./jscadWorker'
 
 const materials = {
   mesh: {
-    def: new MeshPhongMaterial({ color: 0x0084d1, flatShading: true }),
+    def: new MeshPhongMaterial({ color: 0x13579d, flatShading: true }),
     material: (params) => new MeshPhongMaterial(params),
   },
   line: {


### PR DESCRIPTION
Personally nicer color to be closer to jscad default under current lighting setup in cadHub

current color live cadhub
![image](https://user-images.githubusercontent.com/2480762/148618869-dc84fbe7-4f92-4d06-b010-d594a51cdd9d.png)

new color
![image](https://user-images.githubusercontent.com/2480762/148618832-560b9a41-5244-4581-b0c7-2746c37e1bfd.png)

